### PR TITLE
Fix #22 (Train types <C> does not work)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Use `build/build.js` for making mod-zip file and for processing some files (loca
 1. Viidi - Author and initiator of this mod.
 2. WristWatch - English, fixes.
 3. modo_lv - Nullius compatibility.
+4. [KillTrot](https://github.com/KillTrot)
 
 ## License
 

--- a/script/compositions.lua
+++ b/script/compositions.lua
@@ -12,7 +12,16 @@ function getTrainComposition(train)
     for _, ca in pairs(train.carriages) do
         if ca.type == 'locomotive' then
             -- todo detect direction
-            comp[#comp + 1] = '<'
+            for _, loc in pairs(train.locomotives.front_movers) do
+                if loc.unit_number == ca.unit_number then
+                   comp[#comp + 1] = '<'
+                end
+            end
+            for _, loc in pairs(train.locomotives.back_movers) do
+                if loc.unit_number == ca.unit_number then
+                   comp[#comp + 1] = '>'
+                end
+            end
         elseif ca.type == 'cargo-wagon' then
             comp[#comp + 1] = 'C'
         elseif ca.type == 'fluid-wagon' then


### PR DESCRIPTION
When the type is a locomotive, check the locomotives array of the train and check if it's a front or back mover